### PR TITLE
Bugfix/53 search results goes blank when refreshed

### DIFF
--- a/components/search/Suggestions.vue
+++ b/components/search/Suggestions.vue
@@ -1,6 +1,7 @@
 <template>
     <ul v-if="hasSearchSuggestions" :class="suggestionsClass">
-        <li v-for="suggestion in suggestions.slice(0, 8)" :key="suggestion.id" @click="handleClick(suggestion.id)">
+        <li v-for="suggestion in suggestions.slice(0, 8)" :key="suggestion.id" @click="handleClick(suggestion.id)"
+            class="suggestion-item">
             <img class="suggestion-search-icon" src="~/assets/static-images/search-eye.png" />
             {{ selectedSuggestion(suggestion) }}
         </li>
@@ -56,48 +57,6 @@ function selectedSuggestion(suggestion: PaperUI) {
 </script>
 
 <style scoped>
-.container {
-    width: 60vw;
-}
-
-.form-control {
-    border-color: gray;
-    border-radius: 50vh;
-    height: 10vh;
-}
-
-button.dropdown-toggle:focus {
-    border: none;
-}
-
-button.dropdown-toggle {
-    font-size: 20px;
-}
-
-.search-icon {
-    position: absolute;
-    left: 30px;
-    top: 50%;
-    transform: translateY(-50%);
-    height: 50px;
-    pointer-events: none;
-}
-
-input.form-control {
-    padding-left: 100px;
-    padding-right: 150px;
-}
-
-.vertical-line {
-    position: absolute;
-    right: 130px;
-    top: 50%;
-    transform: translateY(-50%);
-    height: 40px;
-    width: 1px;
-    background-color: #484848;
-}
-
 /* Suggestions List Styles */
 .suggestions-list {
     position: absolute;
@@ -110,9 +69,7 @@ input.form-control {
     border-radius: 50px;
     overflow: hidden;
     list-style: none;
-    padding-top: 10px;
-    padding-left: 0;
-    padding-bottom: 10px;
+    padding: 10px 0;
     margin-top: 20px;
 }
 
@@ -128,5 +85,9 @@ input.form-control {
     position: relative;
     height: 50px;
     padding-right: 15px;
+}
+
+.suggestion-item:hover {
+    background-color: #f0f0f0;
 }
 </style>

--- a/server/stores/research-paper-store.ts
+++ b/server/stores/research-paper-store.ts
@@ -8,6 +8,7 @@ export const useItemStore = defineStore("papers", () => {
   const suggestedPapers = ref<PaperUI[]>([]);
 
   const getSession = getSessionData();
+
   if (getSession !== null) {
     suggestedPapers.value = JSON.parse(getSession);
   }

--- a/server/stores/research-paper-store.ts
+++ b/server/stores/research-paper-store.ts
@@ -1,10 +1,16 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
 import { PaperUI } from "~/types/research-paper-ui";
+import { getSessionData, setSessionData } from "~/utils/sessionStorage";
 
 export const useItemStore = defineStore("papers", () => {
   const researchPapers = ref<PaperUI[]>([]);
   const suggestedPapers = ref<PaperUI[]>([]);
+
+  const getSession = getSessionData();
+  if (getSession !== null) {
+    suggestedPapers.value = JSON.parse(getSession);
+  }
 
   function getPaperStores() {
     return researchPapers.value;
@@ -16,6 +22,9 @@ export const useItemStore = defineStore("papers", () => {
 
   function setSuggestedPaperStores(suggestions: PaperUI[]) {
     suggestedPapers.value = suggestions;
+
+    if (suggestions === null) return;
+    setSessionData(suggestions);
   }
 
   function getSuggestedPaperStores() {

--- a/utils/sessionStorage.ts
+++ b/utils/sessionStorage.ts
@@ -9,7 +9,7 @@ export function setSessionData(papers: PaperUI[]) {
 
 export function getSessionData() {
   if (typeof window !== "undefined") {
-    return sessionStorage.getItem("reserachPaperStored");
+    return sessionStorage.getItem("researchPaperStored");
   }
   return null;
 }

--- a/utils/sessionStorage.ts
+++ b/utils/sessionStorage.ts
@@ -1,0 +1,14 @@
+import type { PaperUI } from "~/types/research-paper-ui";
+
+export function setSessionData(papers: PaperUI[]) {
+  if (typeof window !== "undefined") {
+    sessionStorage.setItem("itemsStored", JSON.stringify(papers));
+  }
+}
+
+export function getSessionData() {
+  if (typeof window !== "undefined") {
+    return sessionStorage.getItem("itemsStored");
+  }
+  return null;
+}

--- a/utils/sessionStorage.ts
+++ b/utils/sessionStorage.ts
@@ -1,14 +1,15 @@
 import type { PaperUI } from "~/types/research-paper-ui";
+// To save state in one session
 
 export function setSessionData(papers: PaperUI[]) {
   if (typeof window !== "undefined") {
-    sessionStorage.setItem("itemsStored", JSON.stringify(papers));
+    sessionStorage.setItem("researchPaperStored", JSON.stringify(papers));
   }
 }
 
 export function getSessionData() {
   if (typeof window !== "undefined") {
-    return sessionStorage.getItem("itemsStored");
+    return sessionStorage.getItem("reserachPaperStored");
   }
   return null;
 }


### PR DESCRIPTION
## Problem/Issue:
- #53 

1. Search states are saved in Pinia stores, but the data is lost when the page is refreshed.
2. There is no hover effect in the search suggestions.

## Proposed Solution:

1. Added `SessionStorage` to handle the user's search state.
2. Implemented a hover effect in the search suggestions list.